### PR TITLE
Add Embed V3 models and API changes

### DIFF
--- a/examples/cmd/embed/main.go
+++ b/examples/cmd/embed/main.go
@@ -24,7 +24,7 @@ func main() {
 				"Hello world",
 				"Ciao mondo",
 			},
-			Model:     model.EmbedModelEnglishLightV30,
+			Model:     model.EmbedModelEnglishV30,
 			InputType: &inputType,
 		},
 		resp,

--- a/examples/cmd/embed/main.go
+++ b/examples/cmd/embed/main.go
@@ -16,6 +16,7 @@ func main() {
 	client := coherego.New(os.Getenv("COHERE_API_KEY"))
 
 	resp := &response.Embed{}
+	inputType := model.EmbedSearchQuery
 	err := client.Embed(
 		context.Background(),
 		&request.Embed{
@@ -23,8 +24,8 @@ func main() {
 				"Hello world",
 				"Ciao mondo",
 			},
-			Model: model.EmbedModelEnglishV30,
-			InputType: model.EmbedSearchQuery,
+			Model:     model.EmbedModelEnglishLightV30,
+			InputType: &inputType,
 		},
 		resp,
 	)

--- a/examples/cmd/embed/main.go
+++ b/examples/cmd/embed/main.go
@@ -6,6 +6,7 @@ import (
 	"os"
 
 	coherego "github.com/henomis/cohere-go"
+	"github.com/henomis/cohere-go/model"
 	"github.com/henomis/cohere-go/request"
 	"github.com/henomis/cohere-go/response"
 )
@@ -22,6 +23,8 @@ func main() {
 				"Hello world",
 				"Ciao mondo",
 			},
+			Model: model.EmbedModelEnglishV30,
+			InputType: model.EmbedSearchQuery,
 		},
 		resp,
 	)

--- a/model/models.go
+++ b/model/models.go
@@ -11,17 +11,40 @@ const (
 
 type EmbedModel string
 
+// English
 const (
-	EmbedModelEnglishLightV20 EmbedModel = "embed-english-light-v2.0"
-	EmbedModelMultilingualV20 EmbedModel = "embed-multilingual-v2.0"
+	EmbedModelEnglishV30      EmbedModel = "embed-english-v3.0"
+	EmbedModelEnglishLightV30 EmbedModel = "embed-english-light-v3.0"
 	EmbedModelEnglishV20      EmbedModel = "embed-english-v2.0"
+	EmbedModelEnglishLightV20 EmbedModel = "embed-english-light-v2.0"
+)
+
+// Multilingual
+const (
+	EmbedModelMultilingualV30      EmbedModel = "embed-multilingual-v3.0"
+	EmbedModelMultilingualLightV30 EmbedModel = "embed-multilingual-light-v3.0"
+	EmbedModelMultilingualV20      EmbedModel = "embed-multilingual-v2.0"
 )
 
 var EmbedModelsSize = map[EmbedModel]int{
-	EmbedModelEnglishLightV20: 1024,
+	EmbedModelEnglishV30:      1024,
+	EmbedModelEnglishLightV30: 384,
 	EmbedModelEnglishV20:      4096,
-	EmbedModelMultilingualV20: 768,
+	EmbedModelEnglishLightV20: 1024,
+	
+	EmbedModelMultilingualV30:      1024,
+	EmbedModelMultilingualLightV30: 384,
+	EmbedModelMultilingualV20:      768,
 }
+
+type EmbedInputType string
+
+const (
+	EmbedSearchQuery    EmbedInputType = "search_query"
+	EmbedSearchDocument EmbedInputType = "search_document"
+	EmbedClassification EmbedInputType = "classification"
+	EmbedClustering     EmbedInputType = "clustering"
+)
 
 type ReturnLikelihoods string
 

--- a/model/models.go
+++ b/model/models.go
@@ -31,7 +31,7 @@ var EmbedModelsSize = map[EmbedModel]int{
 	EmbedModelEnglishLightV30: 384,
 	EmbedModelEnglishV20:      4096,
 	EmbedModelEnglishLightV20: 1024,
-	
+
 	EmbedModelMultilingualV30:      1024,
 	EmbedModelMultilingualLightV30: 384,
 	EmbedModelMultilingualV20:      768,

--- a/request/embed.go
+++ b/request/embed.go
@@ -9,10 +9,10 @@ import (
 )
 
 type Embed struct {
-	Texts    []string               `json:"texts"`
-	Model    *model.EmbedModel      `json:"model,omitempty"`
-	InputType *model.EmbedInputType `json:"input_type,omitempty`
-	Truncate *model.Truncate        `json:"truncate,omitempty"`
+	Texts     []string              `json:"texts"`
+	Model     model.EmbedModel      `json:"model,omitempty"`
+	InputType *model.EmbedInputType `json:"input_type,omitempty"`
+	Truncate  *model.Truncate       `json:"truncate,omitempty"`
 }
 
 func (e *Embed) Path() (string, error) {

--- a/request/embed.go
+++ b/request/embed.go
@@ -9,9 +9,10 @@ import (
 )
 
 type Embed struct {
-	Texts    []string          `json:"texts"`
-	Model    *model.EmbedModel `json:"model,omitempty"`
-	Truncate *model.Truncate   `json:"truncate,omitempty"`
+	Texts    []string               `json:"texts"`
+	Model    *model.EmbedModel      `json:"model,omitempty"`
+	InputType *model.EmbedInputType `json:"input_type,omitempty`
+	Truncate *model.Truncate        `json:"truncate,omitempty"`
 }
 
 func (e *Embed) Path() (string, error) {


### PR DESCRIPTION
This PR adds support for the new  Cohere embedding models including`embed-english-v3.0`. It also adds the needed `input_type` parameter